### PR TITLE
another doubling in performance

### DIFF
--- a/src/main/java/org/komamitsu/fastuuidparser/FastUuidParser.java
+++ b/src/main/java/org/komamitsu/fastuuidparser/FastUuidParser.java
@@ -1,64 +1,80 @@
 package org.komamitsu.fastuuidparser;
 
+import java.util.Objects;
 import java.util.UUID;
 
 public final class FastUuidParser
 {
     public static UUID fromString(String s)
     {
+        Objects.requireNonNull(s);
+
         if (s.length() != 36
                 || s.charAt(8) != '-'
                 || s.charAt(13) != '-'
                 || s.charAt(18) != '-'
                 || s.charAt(23) != '-') {
-            throw new IllegalArgumentException("Invalid UUID string: " + s);
+            throw new IllegalArgumentException("Invalid UUID-format: " + s);
         }
 
-        long mostSigBits = parseHexStrToLong(s.substring(0, 8));
-        mostSigBits <<= 16;
-        mostSigBits |= parseHexStrToLong(s.substring(9, 13));
-        mostSigBits <<= 16;
-        mostSigBits |= parseHexStrToLong(s.substring(14, 18));
+        long mostSigBits = parseHexStrToLong(s, 0, 18);
 
-        long leastSigBits = parseHexStrToLong(s.substring(19, 23));
-        leastSigBits <<= 48;
-        leastSigBits |= parseHexStrToLong(s.substring(24, 36));
+        long leastSigBits = parseHexStrToLong(s, 19, 36);
 
         return new UUID(mostSigBits, leastSigBits);
     }
 
-    private static long parseHexStrToLong(String s)
+    private static long parseHexStrToLong(String s, int startPos, int endPos)
     {
         long result = 0;
-        int i = 0, len = s.length();
-        int digit;
 
-        while (i < len) {
-            // Accumulating negatively avoids surprises near MAX_VALUE
-             // digit = Character.digit(s.charAt(i++), 16);
-            digit = hexdigit(s.charAt(i++));
-            if (digit < 0) {
-                throw new IllegalArgumentException("Invalid UUID string: " + s);
+        for (int cursor = startPos; cursor < endPos; cursor++) {
+
+            final byte digit = hexToDigit(s, cursor);
+
+            //skip signal
+            if(digit == -1){
+                continue;
             }
+
+            //shift left 4 bit, make room for the latest byte
             result <<= 4;
+
+            // Accumulating negatively avoids surprises near MAX_VALUE
             result -= digit;
         }
+
         return -result;
     }
 
-    private static int hexdigit(char c)
+    private static byte hexToDigit(String s, int position)
     {
-        if (c >= '0' && c <= '9') {
-            return c - '0';
-        }
-        else if (c >= 'a' && c <= 'f') {
-            return c - 'a' + 10;
-        }
-        else if (c >= 'A' && c <= 'F') {
-            return c - 'A' + 10;
-        }
-        else {
-            return -1;
+        switch (s.charAt(position)) {
+            case '-': return -1;
+            case '0': return 0;
+            case '1': return 1;
+            case '2': return 2;
+            case '3': return 3;
+            case '4': return 4;
+            case '5': return 5;
+            case '6': return 6;
+            case '7': return 7;
+            case '8': return 8;
+            case '9': return 9;
+            case 'a':
+            case 'A': return 10;
+            case 'b':
+            case 'B': return 11;
+            case 'c':
+            case 'C': return 12;
+            case 'd':
+            case 'D': return 13;
+            case 'e':
+            case 'E': return 14;
+            case 'f':
+            case 'F': return 15;
+            default:  throw new IllegalArgumentException(String.format("Invalid UUID-format at position %d: %s", position, s));
         }
     }
 }
+


### PR DESCRIPTION
@berndhopp
some more optimizations: 
 - the avoidance of substring(), which eliminates the need to allocate new char-arrays
 - hexDigit() now uses a simple switch-case, which is (probably) a tiny bit faster than the former implementation
 - avoid bitshifting by parsing complete long at once
 - byte is sufficient for parsed hex

test results now show performance at 7.96 times better than UUID::fromString. I don't see any more optimizations possible at this point.

Benchmark                            Mode  Cnt      Score     Error   Units
FastUuidParserBenchmark.fromString  thrpt   20  16921.608 ± 258.043  ops/ms
NormalUUIDBenchmark.fromString      thrpt   20   2124.604 ±  13.355  ops/ms
